### PR TITLE
Fix default config

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -1,12 +1,20 @@
-description: Generated through flow launcher
-name: default
+name: "Default Setup"
+description: "Demonstrates a possible terminal configuration option"
 window:
   tabs:
-  - directory: C:\Users\samue\AppData\Roaming\FlowLauncher\Plugins\terminal-profiles\configs
-    profile: PowerShell
-    splits:
-    - direction: vertical
-      size: 0.5
-    - direction: horizontal
-      size: 0.3
+    - profile: "PowerShell"
+      directory: "%USERPROFILE%"
+      title: "Development"
+      splits:
+        - direction: "vertical"
+          size: 0.5
+
+        - direction: "horizontal"
+          directory: "%USERPROFILE%"
+          size: 0.3
+
+
+    - profile: "PowerShell"
+      directory: "%USERPROFILE%"
+      title: "Tab 2"
 

--- a/plugin/terminal_config_launcher.py
+++ b/plugin/terminal_config_launcher.py
@@ -38,10 +38,10 @@ class TerminalConfigLauncher:
 
                 tab_command = tab.get('command')
                 if tab_command:
-                    cmd.append(f'powershell -Command "{tab_command}"')
+                    cmd.append(f'powershell -NoExit -Command "{tab_command}"')
                 
                 splits = tab.get('splits', [])
-                for j, split in enumerate(splits):
+                for _, split in enumerate(splits):
                     cmd.append(';')
                     
                     # Determine split direction


### PR DESCRIPTION
## Config fix
Addresses #2 - couldn't access starting directory.

There was a hard-coded local directory on my machine present in the default config. 😅 
Now it should target the `%USERPROFILE%` directory.

I hope that no issues arise from PowerShell profile. I believe it's present by default on Windows machines.

## `--NoExit`

Added --NoExit command for command argument in config. This should allow for more possibilities. 
